### PR TITLE
MJ - Recommendation Request Edit Page

### DIFF
--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,11 +1,78 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function RecommendationRequestEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: recommendationRequest,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/recommendationrequest?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/recommendationrequest`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequest",
+    method: "PUT",
+    params: {
+      id: recommendationRequest.id,
+    },
+    data: {
+      requesterEmail: recommendationRequest.requesterEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: recommendationRequest.dateRequested,
+      dateNeeded: recommendationRequest.dateNeeded,
+      done: recommendationRequest.done,
+    },
+  });
+
+  const onSuccess = (recommendationRequest) => {
+    toast(`Recommendation Request Updated - id: ${recommendationRequest.id}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/recommendationrequest?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Recommendation Request</h1>
+        {recommendationRequest && (
+          <RecommendationRequestForm
+            initialContents={recommendationRequest}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestEditPage",
+  component: RecommendationRequestEditPage,
+};
+
+const Template = () => <RecommendationRequestEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequest", () => {
+      return HttpResponse.json(recommendationRequestFixtures.threeRequests[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/recommendationrequest", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
@@ -1,43 +1,245 @@
-import { render, screen } from "@testing-library/react";
-import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("RecommendationRequestEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+import mockConsole from "jest-mock-console";
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
-    setupUserOnly();
+describe("RecommendationRequestEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <RecommendationRequestEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/recommendationrequest", { params: { id: 17 } })
+        .timeout();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Recommendation Request");
+      expect(
+        screen.queryByTestId("RecommendationRequestForm-requesterEmail"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/recommendationrequest", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          requesterEmail: "get@email.com",
+          professorEmail: "get@email.com",
+          explanation: "get",
+          dateRequested: "2022-03-14T15:00",
+          dateNeeded: "2022-03-14T15:00",
+          done: false,
+        });
+      axiosMock.onPut("/api/recommendationrequest").reply(200, {
+        id: "17",
+        requesterEmail: "put@email.com",
+        professorEmail: "put@email.com",
+        explanation: "put",
+        dateRequested: "2022-12-25T08:00",
+        dateNeeded: "2022-12-25T08:00",
+        done: true,
+      });
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+
+      const idField = screen.getByTestId("RecommendationRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "RecommendationRequestForm-requesterEmail",
+      );
+      const professorEmailField = screen.getByTestId(
+        "RecommendationRequestForm-professorEmail",
+      );
+      const explanationField = screen.getByTestId(
+        "RecommendationRequestForm-explanation",
+      );
+      const dateRequestedField = screen.getByTestId(
+        "RecommendationRequestForm-dateRequested",
+      );
+      const dateNeededField = screen.getByTestId(
+        "RecommendationRequestForm-dateNeeded",
+      );
+      const doneField = screen.getByTestId("RecommendationRequestForm-done");
+      const submitButton = screen.getByTestId(
+        "RecommendationRequestForm-submit",
+      );
+
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toHaveValue("get@email.com");
+      expect(professorEmailField).toHaveValue("get@email.com");
+      expect(explanationField).toHaveValue("get");
+      expect(dateRequestedField).toHaveValue("2022-03-14T15:00");
+      expect(dateNeededField).toHaveValue("2022-03-14T15:00");
+      expect(doneField).toHaveValue("false");
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecommendationRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+
+      const idField = screen.getByTestId("RecommendationRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "RecommendationRequestForm-requesterEmail",
+      );
+      const professorEmailField = screen.getByTestId(
+        "RecommendationRequestForm-professorEmail",
+      );
+      const explanationField = screen.getByTestId(
+        "RecommendationRequestForm-explanation",
+      );
+      const dateRequestedField = screen.getByTestId(
+        "RecommendationRequestForm-dateRequested",
+      );
+      const dateNeededField = screen.getByTestId(
+        "RecommendationRequestForm-dateNeeded",
+      );
+      const doneField = screen.getByTestId("RecommendationRequestForm-done");
+      const submitButton = screen.getByTestId(
+        "RecommendationRequestForm-submit",
+      );
+
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toHaveValue("get@email.com");
+      expect(professorEmailField).toHaveValue("get@email.com");
+      expect(explanationField).toHaveValue("get");
+      expect(dateRequestedField).toHaveValue("2022-03-14T15:00");
+      expect(dateNeededField).toHaveValue("2022-03-14T15:00");
+      expect(doneField).toHaveValue("false");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "put@email.com" },
+      });
+      fireEvent.change(professorEmailField, {
+        target: { value: "put@email.com" },
+      });
+      fireEvent.change(explanationField, { target: { value: "put" } });
+      fireEvent.change(dateRequestedField, {
+        target: { value: "2022-12-25T08:00" },
+      });
+      fireEvent.change(dateNeededField, {
+        target: { value: "2022-12-25T08:00" },
+      });
+      fireEvent.change(doneField, { target: { value: true } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "Recommendation Request Updated - id: 17",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/recommendationrequest",
+      });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          requesterEmail: "put@email.com",
+          professorEmail: "put@email.com",
+          explanation: "put",
+          dateRequested: "2022-12-25T08:00",
+          dateNeeded: "2022-12-25T08:00",
+          done: "true",
+        }),
+      ); // posted object
+    });
   });
 });


### PR DESCRIPTION
Closes #33 

Adds Edit Page for Recommendation Requests
Adds testing for Edit Page

Passes Stryker

Alot of Files changed, but most are since the PR before this isn't approved yet.
Misnamed the stories.js for Edit page, but it is corrected in the Index Page PR.

https://67218c0899dcd8753c78278a-uadxtoffld.chromatic.com/?path=/docs/pages-recommendationrequest-recommendationrequesteditpage--docs

The page should look like this at first:
<img width="970" alt="image" src="https://github.com/user-attachments/assets/9e4154d4-8dc5-4d92-9404-5c88005aca05">

If any fields are left blank it should look like this: 
<img width="982" alt="image" src="https://github.com/user-attachments/assets/e13c72a2-990a-4ba9-bb93-8ee158e731de">

When fields are filled correctly and update button is pressed, pop-up should look similar in the top right:
<img width="991" alt="image" src="https://github.com/user-attachments/assets/ab3e539e-d5fa-4285-b89f-e1c0004a4ea8">

