### PR TITLE
eg - create HelpRequest page

### DIFF
--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -19,7 +19,9 @@ export default function HelpRequestCreatePage({ storybook = false }) {
   });
 
   const onSuccess = (helpRequest) => {
-    toast(`New helpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`);
+    toast(
+      `New helpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`,
+    );
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/helprequest/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(`New helpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/helperquest/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Help Request</h1>
+
+        <HelpRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestCreatePage",
+  component: HelpRequestCreatePage,
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/helprequest/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,10 +8,33 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
+
 describe("HelpRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +43,10 @@ describe("HelpRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +55,100 @@ describe("HelpRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("HelpRequestForm-requesterEmail"),
+      ).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const helpRequest = {
+      id: 17,
+      requesterEmail: "testing@ucsb.edu",
+      teamId: "f24-5pm-11",
+      tableOrBreakoutRoom: "6",
+      requestTime: "2024-11-07T00:57:15.000",
+      explanation: "testing create page",
+      solved: "false",
+    };
+
+    axiosMock.onPost("/api/helprequest/post").reply(202, helpRequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("HelpRequestForm-requesterEmail"),
+      ).toBeInTheDocument();
+    });
+
+    const requesterEmailField = screen.getByTestId(
+      "HelpRequestForm-requesterEmail",
+    );
+    const teamIdField = screen.getByTestId(
+      "HelpRequestForm-teamId",
+    );
+    const tableOrBreakoutRoomField = screen.getByTestId(
+      "HelpRequestForm-tableOrBreakoutRoom",
+    );
+    const requestTimeField = screen.getByTestId(
+      "HelpRequestForm-requestTime"
+    );
+    const explanationField = screen.getByTestId(
+      "HelpRequestForm-explanation"
+    );
+    const solvedField = screen.getByTestId(
+      "HelpRequestForm-solved"
+    );
+    const submitButton = screen.getByTestId(
+      "HelpRequestForm-submit"
+    );
+
+    fireEvent.change(requesterEmailField, {
+      target: { value: "testing@ucsb.edu" },
+    });
+    fireEvent.change(teamIdField, { 
+      target: { value: "f24-5pm-11" } 
+    });
+    fireEvent.change(tableOrBreakoutRoomField, { 
+      target: { value: "6" } 
+    });
+    fireEvent.change(requestTimeField, {
+      target: { value: "2024-11-07T00:57:15.000" },
+    });
+    fireEvent.change(explanationField, { 
+      target: { value: "testing create page" } 
+    });
+    fireEvent.change(solvedField, { 
+      target: { value: "false" } 
+    });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requesterEmail: "testing@ucsb.edu",
+      teamId: "f24-5pm-11",
+      tableOrBreakoutRoom: "6",
+      requestTime: "2024-11-07T00:57:15.000",
+      explanation: "testing create page",
+      solved: "false",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New helpRequest Created - id: 17 requesterEmail: testing@ucsb.edu",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/helprequest" });
   });
 });

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -93,42 +93,32 @@ describe("HelpRequestCreatePage tests", () => {
     const requesterEmailField = screen.getByTestId(
       "HelpRequestForm-requesterEmail",
     );
-    const teamIdField = screen.getByTestId(
-      "HelpRequestForm-teamId",
-    );
+    const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
     const tableOrBreakoutRoomField = screen.getByTestId(
       "HelpRequestForm-tableOrBreakoutRoom",
     );
-    const requestTimeField = screen.getByTestId(
-      "HelpRequestForm-requestTime"
-    );
-    const explanationField = screen.getByTestId(
-      "HelpRequestForm-explanation"
-    );
-    const solvedField = screen.getByTestId(
-      "HelpRequestForm-solved"
-    );
-    const submitButton = screen.getByTestId(
-      "HelpRequestForm-submit"
-    );
+    const requestTimeField = screen.getByTestId("HelpRequestForm-requestTime");
+    const explanationField = screen.getByTestId("HelpRequestForm-explanation");
+    const solvedField = screen.getByTestId("HelpRequestForm-solved");
+    const submitButton = screen.getByTestId("HelpRequestForm-submit");
 
     fireEvent.change(requesterEmailField, {
       target: { value: "testing@ucsb.edu" },
     });
-    fireEvent.change(teamIdField, { 
-      target: { value: "f24-5pm-11" } 
+    fireEvent.change(teamIdField, {
+      target: { value: "f24-5pm-11" },
     });
-    fireEvent.change(tableOrBreakoutRoomField, { 
-      target: { value: "6" } 
+    fireEvent.change(tableOrBreakoutRoomField, {
+      target: { value: "6" },
     });
     fireEvent.change(requestTimeField, {
       target: { value: "2024-11-07T00:57:15.000" },
     });
-    fireEvent.change(explanationField, { 
-      target: { value: "testing create page" } 
+    fireEvent.change(explanationField, {
+      target: { value: "testing create page" },
     });
-    fireEvent.change(solvedField, { 
-      target: { value: "false" } 
+    fireEvent.change(solvedField, {
+      target: { value: "false" },
     });
 
     expect(submitButton).toBeInTheDocument();


### PR DESCRIPTION
Closes #49 

Storybook: https://67218c0899dcd8753c78278a-axlmabuegy.chromatic.com/?path=/docs/pages-helprequest-helprequestcreatepage--docs

- adds a create page to create a new help request
- passes all tests

Testing:

Launch localhost
Go to /helprequest/create
Enter relevant info in all of the fields. Make sure 'Request Time' follows iso format. Do not leave any fields blank.
![Screenshot 2024-11-06 174833](https://github.com/user-attachments/assets/350ddee2-7b66-457b-be10-492a6e4569f0)

Click create and, if successful, you will be taken back to index page and you should see a successful request message at the top of the page.
![Screenshot 2024-11-06 174907](https://github.com/user-attachments/assets/89b444b9-8c08-432e-af92-e3434aa3273e)


Go to swagger, navigate to api/helprequest, get a single help request by id
Enter in the id of the request you made
![Screenshot 2024-11-06 174958](https://github.com/user-attachments/assets/125744ca-e285-4202-aa8d-c40b6a8996d8)

You should then see your help request data
![Screenshot 2024-11-06 175004](https://github.com/user-attachments/assets/776595e8-f9ea-446a-a8b9-4180f874ebba)